### PR TITLE
Alias (p) for push. (v0.5.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "loki-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Kyle W. Rader"]
 description = "A CLI for Git Productivity"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Git is a pretty great tool on it's own. After some time common patterns emerge. 
 
 # Use
 ## Get Help
-```shell
-❯ lk --help
-loki-cli 0.3.0
+```
+loki-cli 0.5.0
 Kyle W. Rader
 A CLI for Git Productivity
 
@@ -32,7 +31,7 @@ SUBCOMMANDS:
     new      Create a new branch from HEAD and push it to origin. Set a prefix for all new
                  branch names with the env var LOKI_NEW_PREFIX [aliases: n]
     pull     Pull with --prune deleting local branches pruned from the remote
-    push     Push the current branch to origin with --set-upstream
+    push     Push the current branch to origin with --set-upstream [aliases: p]
 ```
 
 ## Commands
@@ -50,13 +49,13 @@ Alias: `n`
 Creates and pushes `readme-updates` to origin with `--set-upstream`. (The command git will tell you to run if you simply run `git push` after creating a new local branch.)
 
 ### `push`
-Alias: none
+Alias: `p`
 * Pushes the current branch to origin with `--set-upstream`.
 * `-f|--force` flag uses `--force-with-lease` under the hood for better force push safety.
 * Only works if `HEAD` is on a branch (not in a dettached state).
 
 ### `pull`
-Alias: none
+Alias: none (the alias `p` is for `push`)
 * Run `git pull --prune` and remove any local branches that have also been pruned on the remote.
 
 ### `fetch`

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,3 @@
-tag-name = "{{crate_name}}-{{version}}"
+tag-name = "v{{version}}"
 tag-message = "{{tag_name}}"
 allow-branch = ["main"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ enum Cli {
     },
 
     /// Push the current branch to origin with --set-upstream
+    #[clap(visible_alias = "p")]
     Push {
         /// Use --force-with-lease
         #[clap(short, long)]


### PR DESCRIPTION
Add an alias `p` for `push` given it is the more common command between `push` and `pull`.