### PR TITLE
Add `lk save` to quickly add, commit, and push while rapid prototyping

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
+      - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,9 +1,9 @@
 name: Cargo Test
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,8 +16,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install latest nightly
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
         uses: actions-rs/toolchain@v1
-    - name: cargo test
-      run: cargo test --verbose
+      - name: cargo test
+        run: cargo test --verbose

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,5 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: cargo test
         run: cargo test --verbose

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,5 +17,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
     - name: cargo test
       run: cargo test --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Install cargo-release
         run: |
           export cr_dir=$RUNNER_TEMP/$cr_dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,29 +14,29 @@ jobs:
       cr_dir: cr
       cr_package: "https://github.com/crate-ci/cargo-release/releases/download/v0.20.3/cargo-release-v0.20.3-x86_64-unknown-linux-gnu.tar.gz"
     steps:
-    - uses: actions/checkout@v2
-    - name: Install latest nightly
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
         uses: actions-rs/toolchain@v1
-    - name: Install cargo-release
-      run: |
-        export cr_dir=$RUNNER_TEMP/$cr_dir
-        mkdir -p $cr_dir
-        pushd $cr_dir
-        curl -L $cr_package -o cr.tar.gz
-        tar -xzf cr.tar.gz
-        popd
-    - name: Release
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # Prep auth for pushing tags
-        remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-        git config http.sslVerify false
-        git config --local user.email kylewrader@gmail.com
-        git config --local user.name ${GITHUB_ACTOR}
-        git remote set-url origin $remote_repo
+      - name: Install cargo-release
+        run: |
+          export cr_dir=$RUNNER_TEMP/$cr_dir
+          mkdir -p $cr_dir
+          pushd $cr_dir
+          curl -L $cr_package -o cr.tar.gz
+          tar -xzf cr.tar.gz
+          popd
+      - name: Release
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Prep auth for pushing tags
+          remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config http.sslVerify false
+          git config --local user.email kylewrader@gmail.com
+          git config --local user.name ${GITHUB_ACTOR}
+          git remote set-url origin $remote_repo
 
-        # Run Cargo Release
-        export cr_dir=$RUNNER_TEMP/$cr_dir
-        $cr_dir/$cr release --config release.toml --execute --no-confirm
+          # Run Cargo Release
+          export cr_dir=$RUNNER_TEMP/$cr_dir
+          $cr_dir/$cr release --config release.toml --execute --no-confirm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       cr_package: "https://github.com/crate-ci/cargo-release/releases/download/v0.20.3/cargo-release-v0.20.3-x86_64-unknown-linux-gnu.tar.gz"
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
+      - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
       cr_package: "https://github.com/crate-ci/cargo-release/releases/download/v0.20.3/cargo-release-v0.20.3-x86_64-unknown-linux-gnu.tar.gz"
     steps:
     - uses: actions/checkout@v2
+    - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
     - name: Install cargo-release
       run: |
         export cr_dir=$RUNNER_TEMP/$cr_dir

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ version = "0.5.0"
 dependencies = [
  "clap",
  "test-case",
+ "time",
 ]
 
 [[package]]
@@ -117,6 +118,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -170,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +229,24 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "time"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+dependencies = [
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
+time = { version = "0.3.17", features = ["local-offset"] }
 
 [dev-dependencies]
 test-case = "2.0.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "stable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/src/git.rs
+++ b/src/git.rs
@@ -6,6 +6,7 @@ use std::{
 
 const GIT: &str = "git";
 
+/// Execute the git command returning an error if it fails. No redirection is done.
 pub fn git_command_status<I, S>(name: &str, args: I) -> Result<(), String>
 where
     I: IntoIterator<Item = S>,
@@ -17,6 +18,7 @@ where
     Ok(())
 }
 
+/// Execute the list of git commands in order, returning on the first failure. No redirection is done.
 pub fn git_commands_status<C, I, S>(commands: C) -> Result<(), String>
 where
     C: IntoIterator<Item = (&'static str, I)>,


### PR DESCRIPTION
Adds a `save` command. Can be used with `--all` to switch the option used from `--update` to `--all`. (`--update` used by default). 