### PR TITLE
Add commit command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "loki-cli"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "clap",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"


### PR DESCRIPTION
This adds `lk c` or `lk commit` with the same options as the `save` command (`--all` and `message`, the remaining args joined on whitespace).

We also add aliases for 
* `save` = `s`
* `commit` = `c`
