### PR TITLE
Highlight deleted branches in pruning output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "loki-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "clap",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/src/pruning.rs
+++ b/src/pruning.rs
@@ -1,11 +1,29 @@
 const ORIGIN: &str = "origin/";
 const DELETED: &str = " - [deleted]";
+const RED: &str = "\u{1b}[31m";
+const RESET: &str = "\u{1b}[0m";
 
 pub fn is_pruned_branch(s: String) -> Option<String> {
     s.starts_with(DELETED)
         .then(|| s.find(ORIGIN))
         .flatten()
         .map(|ix| String::from(&s[ix + ORIGIN.len()..]))
+}
+
+pub fn highlight_pruned_branch_line(line: &str, branch: &str) -> String {
+    let remote_branch = format!("{ORIGIN}{branch}");
+    let highlighted_remote_branch = format!("{RED}{remote_branch}{RESET}");
+
+    if line.contains(&remote_branch) {
+        line.replace(remote_branch.as_str(), highlighted_remote_branch.as_str())
+    } else {
+        let highlighted_branch = format!("{RED}{branch}{RESET}");
+        line.replace(branch, highlighted_branch.as_str())
+    }
+}
+
+pub fn highlight_branch_name(branch: &str) -> String {
+    format!("{RED}{branch}{RESET}")
 }
 
 #[cfg(test)]
@@ -33,5 +51,21 @@ mod prune_tests {
         let line = String::from(input);
         let subject = is_pruned_branch(line);
         assert_eq!(subject, None);
+    }
+
+    #[test]
+    fn highlights_remote_branch_in_line() {
+        let line = " - [deleted]         (none)     -> origin/command-push";
+        let highlighted = highlight_pruned_branch_line(line, "command-push");
+        assert!(
+            highlighted.contains("\u{1b}[31morigin/command-push\u{1b}[0m"),
+            "{highlighted} did not highlight the remote branch"
+        );
+    }
+
+    #[test]
+    fn highlights_branch_name() {
+        let highlighted = highlight_branch_name("feature/example");
+        assert_eq!(highlighted, "\u{1b}[31mfeature/example\u{1b}[0m");
     }
 }


### PR DESCRIPTION
Add terminal syntax highlighting to Loki's pruning output to highlight deleted branch names in red.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c7049a1-aefd-4309-9854-0f7c15e02ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c7049a1-aefd-4309-9854-0f7c15e02ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add red ANSI highlighting for pruned branch lines and names during pull/fetch pruning, plus tests and version bump to 0.9.2.
> 
> - **CLI pruning behavior**:
>   - Colorize pruned branch lines using `highlight_pruned_branch_line` when parsing `--prune` output.
>   - Colorize branch names in delete success/error messages via `highlight_branch_name`.
> - **Pruning utilities**:
>   - Add `highlight_pruned_branch_line(line, branch)` and `highlight_branch_name(branch)` with ANSI red/RESET codes in `src/pruning.rs`.
> - **Tests**:
>   - Add tests for highlighting functions and keep existing pruning detection tests.
> - **Version**:
>   - Bump `loki-cli` to `0.9.2` in `Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 490b89cdb0e84815104f3c5bbe266b0647bc0b46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->