### PR TITLE
Update branch prefix to use claps env feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "loki-cli"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "clap",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Loki: 🚀 A Git productivity tool
 Usage: lk <COMMAND>
 
 Commands:
-  new       Create a new branch from HEAD and push it to origin. Set a prefix for all new branch names with the env var LOKI_NEW_PREFIX [aliases: n]
+  new       Create a new branch from HEAD and push it to origin. Set a prefix with --prefix or the LOKI_NEW_PREFIX env var [aliases: n]
   push      Push the current branch to origin with --set-upstream [aliases: p]
   pull      Pull with --prune deleting local branches pruned from the remote
   fetch     Fetch with --prune deleting local branches pruned from the remote
@@ -43,7 +43,7 @@ Options:
 Alias: `n`
 * Make creating a new branch easier to type by joining all given args with a dash (`-`).
 * Automatically push and setup tracking to `origin`.
-* Set a prefix to always prepend with the `LOKI_NEW_PREFIX` environment variable.
+* Set a prefix to always prepend with the `--prefix` flag or the `LOKI_NEW_PREFIX` environment variable.
 
 #### Example
 ```


### PR DESCRIPTION
Add a `--prefix` CLI option to `lk new` to set the branch name prefix, leveraging Clap's `env` feature for `LOKI_NEW_PREFIX`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b923c1e-de5d-4849-a93c-dff62e431e74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b923c1e-de5d-4849-a93c-dff62e431e74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional --prefix flag (and LOKI_NEW_PREFIX via Clap env) to `lk new`, updates help/docs, and bumps version to 0.9.3.
> 
> - **CLI**:
>   - `new` subcommand: add optional `--prefix` (also reads `LOKI_NEW_PREFIX` via Clap `env`) and pass it into `new_branch`.
>   - Update `new_branch` signature to accept `prefix: Option<&str>` and adjust prefix handling/logging.
> - **Docs**:
>   - Refresh `README.md` and help text to document `--prefix` and `LOKI_NEW_PREFIX` usage.
> - **Build/Config**:
>   - Enable Clap `env` feature in `Cargo.toml`.
>   - Bump crate version from `0.9.2` to `0.9.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad421455a94be7936d5abb939d18f4f53d00cbcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->