### PR TITLE
Add agent docs and author stats command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+## Agent Contribution Guide
+
+Whenever an automated agent lands code in this repository, it must also:
+
+- Bump the crate version in `Cargo.toml` before shipping.
+- Choose the bump size using semantic versioning rules:
+  - Increment the **major** version (`x.0.0`) for breaking changes.
+  - Increment the **minor** version when adding backward-compatible functionality.
+  - Increment the **patch** version for bug fixes and other backward-compatible maintenance work.
+
+If you are unsure which category applies, err on the side of a **minor** bump and leave a note in your PR with the reasoning.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "0.11.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,10 +61,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "cc"
+version = "1.2.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -106,10 +150,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -118,12 +198,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
-name = "loki-cli"
-version = "0.9.3"
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "loki-cli"
+version = "0.10.0"
+dependencies = [
+ "chrono",
  "clap",
  "test-case",
 ]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "proc-macro2"
@@ -142,6 +260,18 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"
@@ -225,6 +355,110 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive", "unicode", "env"] }
+chrono = { version = "0.4", features = ["clock"] }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.11.0"
+version = "0.10.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,11 @@ pub mod git;
 pub mod pruning;
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use chrono::{DateTime, Duration as ChronoDuration, Months, NaiveDate, Utc};
 use clap::{
     builder::{styling::AnsiColor, Styles},
     Parser, Subcommand,
@@ -37,6 +38,29 @@ struct CommitOptions {
 
     /// Optional message to include. Each MESSAGE will be joined on whitespace.
     message: Vec<String>,
+}
+
+#[derive(Debug, Parser)]
+struct AuthorStatsOptions {
+    /// Limit analysis to commits from the last N days.
+    #[clap(long, conflicts_with_all = &["weeks", "months", "from"])]
+    days: Option<u32>,
+
+    /// Limit analysis to commits from the last N weeks.
+    #[clap(long, conflicts_with_all = &["days", "months", "from"])]
+    weeks: Option<u32>,
+
+    /// Limit analysis to commits from the last N months.
+    #[clap(long, conflicts_with_all = &["days", "weeks", "from"])]
+    months: Option<u32>,
+
+    /// Include commits starting from YYYY-MM-DD (overrides --days/--weeks/--months).
+    #[clap(long, value_parser = parse_naive_date, conflicts_with_all = &["days", "weeks", "months"])]
+    from: Option<NaiveDate>,
+
+    /// Include commits through YYYY-MM-DD (defaults to today).
+    #[clap(long, value_parser = parse_naive_date)]
+    to: Option<NaiveDate>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -105,9 +129,14 @@ enum Cli {
         #[clap(subcommand)]
         command: RepoSubcommand,
     },
+
+    /// Analyze first-parent commits by author over time.
+    #[clap(name = "author-stats")]
+    AuthorStats(AuthorStatsOptions),
 }
 
 const LOKI_NEW_PREFIX: &str = "LOKI_NEW_PREFIX";
+const AUTHOR_GRAPH_WIDTH: usize = 40;
 
 fn main() -> Result<(), String> {
     let cli = Cli::parse();
@@ -124,6 +153,7 @@ fn main() -> Result<(), String> {
         Cli::Repo {
             command: RepoSubcommand::Stats,
         } => repo_stats(),
+        Cli::AuthorStats(options) => author_stats(options),
     }
 }
 
@@ -220,6 +250,264 @@ fn repo_stats() -> Result<(), String> {
     }
 
     Ok(())
+}
+
+struct TimeRange {
+    start_ts: Option<i64>,
+    end_ts: i64,
+    start_label: String,
+    end_label: String,
+    end_is_latest: bool,
+}
+
+fn author_stats(options: &AuthorStatsOptions) -> Result<(), String> {
+    let range = resolve_time_range(options)?;
+    let log_lines = git::git_command_lines(
+        "collect author stats",
+        vec!["log", "--first-parent", "--pretty=format:%ct%x09%an", "HEAD"],
+    )?;
+
+    let mut totals: HashMap<String, usize> = HashMap::new();
+    let mut timeline: BTreeMap<NaiveDate, HashMap<String, usize>> = BTreeMap::new();
+
+    for raw_line in log_lines {
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let (timestamp_part, author_part) = trimmed.split_once('\t').ok_or_else(|| {
+            format!("Unexpected git log output (expected `<timestamp>\\t<author>`): `{trimmed}`")
+        })?;
+
+        let timestamp = timestamp_part.parse::<i64>().map_err(|err| {
+            format!("Failed to parse git log timestamp `{timestamp_part}`: {err}")
+        })?;
+
+        if timestamp > range.end_ts {
+            continue;
+        }
+        if let Some(start_ts) = range.start_ts {
+            if timestamp < start_ts {
+                continue;
+            }
+        }
+
+        let author = author_part.trim();
+        let author = if author.is_empty() {
+            String::from("Unknown")
+        } else {
+            author.to_string()
+        };
+
+        let date = DateTime::from_timestamp(timestamp, 0)
+            .ok_or_else(|| format!("Commit timestamp out of range: {timestamp}"))?
+            .date_naive();
+
+        *totals.entry(author.clone()).or_insert(0) += 1;
+        timeline
+            .entry(date)
+            .or_insert_with(HashMap::new)
+            .entry(author)
+            .and_modify(|count| *count += 1)
+            .or_insert(1);
+    }
+
+    if totals.is_empty() {
+        println!(
+            "No first-parent commits found between {} and {}.",
+            range.start_label, range.end_label
+        );
+        return Ok(());
+    }
+
+    let mut author_counts: Vec<(String, usize)> = totals.into_iter().collect();
+    author_counts.sort_by(|(author_a, count_a), (author_b, count_b)| {
+        count_b.cmp(count_a).then_with(|| author_a.cmp(author_b))
+    });
+
+    let total_commits: usize = author_counts.iter().map(|(_, count)| *count).sum();
+
+    let resolved_end_label = if range.end_is_latest {
+        timeline
+            .keys()
+            .next_back()
+            .map(|date| format!("{date} (latest commit)"))
+            .unwrap_or_else(|| String::from("latest commit"))
+    } else {
+        range.end_label.clone()
+    };
+
+    println!(
+        "First-parent commits between {} and {}: {} total ({} authors).",
+        range.start_label,
+        resolved_end_label,
+        total_commits,
+        author_counts.len()
+    );
+    println!("Commits by author:");
+    for (author, count) in &author_counts {
+        println!("  {author}: {count}");
+    }
+
+    print_author_graph(&author_counts);
+    print_timeline(&timeline);
+
+    Ok(())
+}
+
+fn print_author_graph(author_counts: &[(String, usize)]) {
+    if author_counts.is_empty() {
+        return;
+    }
+
+    let max_author_len = author_counts
+        .iter()
+        .map(|(author, _)| author.len())
+        .max()
+        .unwrap_or(0);
+    let max_count = author_counts
+        .iter()
+        .map(|(_, count)| *count)
+        .max()
+        .unwrap_or(0);
+
+    if max_count == 0 {
+        return;
+    }
+
+    println!("Commit distribution graph:");
+    for (author, count) in author_counts {
+        let mut bar_len = if max_count == 0 {
+            0
+        } else {
+            ((*count as f64) / (max_count as f64) * AUTHOR_GRAPH_WIDTH as f64).round() as usize
+        };
+        if *count > 0 && bar_len == 0 {
+            bar_len = 1;
+        }
+        bar_len = bar_len.min(AUTHOR_GRAPH_WIDTH);
+
+        let bar = "#".repeat(bar_len);
+        let padding_len = AUTHOR_GRAPH_WIDTH.saturating_sub(bar_len);
+        let padding = " ".repeat(padding_len);
+
+        println!(
+            "{author:<width$} | {}{} ({count})",
+            bar,
+            padding,
+            width = max_author_len
+        );
+    }
+}
+
+fn print_timeline(timeline: &BTreeMap<NaiveDate, HashMap<String, usize>>) {
+    if timeline.is_empty() {
+        return;
+    }
+
+    println!("Daily breakdown (first-parent commits):");
+    for (date, counts) in timeline {
+        let mut entries: Vec<_> = counts.iter().collect();
+        entries.sort_by(|(author_a, count_a), (author_b, count_b)| {
+            count_b.cmp(count_a).then_with(|| author_a.cmp(author_b))
+        });
+        let summary = entries
+            .into_iter()
+            .map(|(author, count)| format!("{author}: {count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("{date} | {summary}");
+    }
+}
+
+fn resolve_time_range(options: &AuthorStatsOptions) -> Result<TimeRange, String> {
+    let now = Utc::now();
+    let (reference_end_dt, end_label, end_is_latest, end_ts) = if let Some(to_date) = options.to {
+        let end_naive = to_date
+            .and_hms_opt(23, 59, 59)
+            .ok_or_else(|| String::from("invalid --to date"))?;
+        let dt = DateTime::<Utc>::from_naive_utc_and_offset(end_naive, Utc);
+        (dt, to_date.to_string(), false, dt.timestamp())
+    } else {
+        (now, String::from("latest commit"), true, i64::MAX)
+    };
+
+    let mut start_label = String::from("initial commit");
+    let mut start_dt: Option<DateTime<Utc>> = None;
+
+    if let Some(from_date) = options.from {
+        let from_naive = from_date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| String::from("invalid --from date"))?;
+        start_dt = Some(DateTime::<Utc>::from_naive_utc_and_offset(from_naive, Utc));
+        start_label = from_date.to_string();
+    } else if let Some(days) = options.days {
+        if days == 0 {
+            return Err(String::from("--days must be greater than zero."));
+        }
+        let dt = reference_end_dt - ChronoDuration::days(days as i64);
+        start_label = format!(
+            "{} (last {} day{})",
+            dt.format("%Y-%m-%d"),
+            days,
+            if days == 1 { "" } else { "s" }
+        );
+        start_dt = Some(dt);
+    } else if let Some(weeks) = options.weeks {
+        if weeks == 0 {
+            return Err(String::from("--weeks must be greater than zero."));
+        }
+        let dt = reference_end_dt - ChronoDuration::weeks(weeks as i64);
+        start_label = format!(
+            "{} (last {} week{})",
+            dt.format("%Y-%m-%d"),
+            weeks,
+            if weeks == 1 { "" } else { "s" }
+        );
+        start_dt = Some(dt);
+    } else if let Some(months_count) = options.months {
+        if months_count == 0 {
+            return Err(String::from("--months must be greater than zero."));
+        }
+        let end_date = reference_end_dt.date_naive();
+        let start_date = end_date
+            .checked_sub_months(Months::new(months_count))
+            .ok_or_else(|| String::from("month subtraction overflow"))?;
+        let start_naive = start_date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| String::from("invalid computed month range"))?;
+        let dt = DateTime::<Utc>::from_naive_utc_and_offset(start_naive, Utc);
+        start_label = format!(
+            "{} (last {} month{})",
+            start_date,
+            months_count,
+            if months_count == 1 { "" } else { "s" }
+        );
+        start_dt = Some(dt);
+    }
+
+    if let Some(start_dt_value) = start_dt {
+        if start_dt_value > reference_end_dt {
+            return Err(String::from(
+                "The computed start date occurs after the end date. Check your filters.",
+            ));
+        }
+    }
+
+    Ok(TimeRange {
+        start_ts: start_dt.map(|dt| dt.timestamp()),
+        end_ts,
+        start_label,
+        end_label,
+        end_is_latest,
+    })
+}
+
+fn parse_naive_date(value: &str) -> Result<NaiveDate, String> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|err| {
+        format!("Invalid date `{value}` (expected YYYY-MM-DD): {err}")
+    })
 }
 
 fn format_duration(duration: Duration) -> String {


### PR DESCRIPTION
Add `AGENTS.md` for agent contribution guidelines and introduce an `author-stats` command to analyze git history with time-based filtering and a terminal graph.

The `AGENTS.md` file provides clear instructions for automated agents on version bumping and semantic versioning. The new `author-stats` command offers a powerful way to visualize and summarize commit activity by author over specified time ranges, enhancing repository analysis capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cb885a1-27c8-4f42-ab42-34d18ca44572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cb885a1-27c8-4f42-ab42-34d18ca44572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `stats` subcommand to analyze first-parent commits by author with time-range filters and a terminal graph, introduces `AGENTS.md`, bumps version to 0.10.0, and adds `chrono`.
> 
> - **CLI**:
>   - **New `stats` subcommand**: Analyze first-parent commits by author with `--days`, `--weeks`, `--months`, `--from`, `--to` filters; outputs per-author counts and a scaled bar graph.
>   - Helpers for time range resolution (`resolve_time_range`), date parsing (`parse_naive_date`), and graph rendering (`print_author_graph`).
> - **Docs**:
>   - Add `AGENTS.md` with agent contribution/versioning guidance.
> - **Release**:
>   - Bump crate version in `Cargo.toml` to `0.10.0`.
>   - Add `chrono` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35bfc8dbcfa53eba9e431b78c68158aef421339a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->