### PR TITLE
Update stats command distribution graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"


### PR DESCRIPTION
Refactor `stats` command to show only the author distribution graph with dot bars and add a `--top` option to limit contributors.

---
<a href="https://cursor.com/background-agent?bcId=bc-54b2a6bc-b2bc-4cc5-9b8f-043e6ae3bb60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-54b2a6bc-b2bc-4cc5-9b8f-043e6ae3bb60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `--top` to `lk stats` to limit contributors and updates output to a dot-based author distribution graph only; bumps version to 0.10.1.
> 
> - **Stats (`src/main.rs`)**
>   - **New option**: `--top <N>` to limit displayed contributors; validates `N > 0`.
>   - **Output change**:
>     - Replaces per-author list with a single distribution graph titled `Commits by author (distribution graph)`.
>     - Graph bars switch from `#` to `.` and respect `--top` filtering.
>     - Keeps total commits and unique author count in summary line; resolves end label for latest commit.
> - **Versioning**
>   - Bump `loki-cli` from `0.10.0` to `0.10.1` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c693b5e6597275a7ee7e30cc3f5814357af70ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->