### PR TITLE
Deduplicate authors by email and username

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"


### PR DESCRIPTION
Update `stats` command to deduplicate authors by username, using the first encountered email, to correctly aggregate contributions from users with multiple email aliases.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6e82711-3ba2-4955-9405-717b87fe082c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6e82711-3ba2-4955-9405-717b87fe082c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates commit authors in `stats` by username, canonicalizing email aliases via a new helper and tests.
> 
> - **Stats command**
>   - Deduplicates authors by username, mapping multiple emails to a canonical email via `canonicalize_author`.
>   - Aggregation keys (`totals`, `timeline`, `email_to_name`) now use canonicalized emails.
>   - Minor output formatting tweak for the summary line.
> - **Implementation**
>   - Adds `fn canonicalize_author(...)` managing `email_aliases` and `name_to_email` maps.
>   - Adds unit tests for alias reuse and name changes.
> - **Meta**
>   - Bump version to `0.10.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbb50aaefedcfba807aab08f0a6d30a7cdc63aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->