### PR TITLE
Consolidate stats command into repo stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "0.10.1"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "0.10.2"
+version = "1.0.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ Execute a git commit without running any hooks
 ```sh
 lk x -- commit -m "Update Readme without running hooks"
 ```
+
+### `repo stats`
+Analyze first-parent commits to see who has been landing work in a repository. All of the filtering flags operate on commit dates.
+
+#### Example
+```
+❯ lk repo stats --weeks 4 --top 5
+```

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ lk x -- commit -m "Update Readme without running hooks"
 ### `repo stats`
 Analyze first-parent commits to see who has been landing work in a repository. All of the filtering flags operate on commit dates.
 
+- `--name` filters by author display name (repeatable, case-insensitive).
+- `--email` filters by author email (repeatable, case-insensitive).
+
 #### Example
 ```
 ❯ lk repo stats --weeks 4 --top 5

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
 pub mod git;
 pub mod pruning;
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::collections::{BTreeMap, HashMap};
 
 use chrono::{DateTime, Duration as ChronoDuration, Months, NaiveDate, Utc};
 use clap::{
@@ -41,7 +38,7 @@ struct CommitOptions {
 }
 
 #[derive(Debug, Parser)]
-struct AuthorStatsOptions {
+struct RepoStatsOptions {
     /// Limit analysis to commits from the last N days.
     #[clap(long, conflicts_with_all = &["weeks", "months", "from"])]
     days: Option<u32>,
@@ -69,8 +66,9 @@ struct AuthorStatsOptions {
 
 #[derive(Debug, Subcommand)]
 enum RepoSubcommand {
-    /// Display repository statistics.
-    Stats,
+    /// Analyze first-parent commits by author over time.
+    #[clap(name = "stats")]
+    Stats(RepoStatsOptions),
 }
 
 #[derive(Parser)]
@@ -133,10 +131,6 @@ enum Cli {
         #[clap(subcommand)]
         command: RepoSubcommand,
     },
-
-    /// Analyze first-parent commits by author over time.
-    #[clap(name = "stats")]
-    Stats(AuthorStatsOptions),
 }
 
 const LOKI_NEW_PREFIX: &str = "LOKI_NEW_PREFIX";
@@ -155,9 +149,8 @@ fn main() -> Result<(), String> {
         Cli::Rebase { target } => rebase(target),
         Cli::NoHooks { command } => no_hooks(command),
         Cli::Repo {
-            command: RepoSubcommand::Stats,
-        } => repo_stats(),
-        Cli::Stats(options) => author_stats(options),
+            command: RepoSubcommand::Stats(options),
+        } => repo_stats(options),
     }
 }
 
@@ -178,84 +171,6 @@ fn no_hooks(command: &[impl AsRef<str>]) -> Result<(), String> {
     Ok(())
 }
 
-fn repo_stats() -> Result<(), String> {
-    let author_lines =
-        git::git_command_lines("collect commit authors", vec!["log", "--pretty=format:%an"])?;
-
-    if author_lines.is_empty() {
-        println!("No commits found.");
-        return Ok(());
-    }
-
-    let mut author_counts: HashMap<String, usize> = HashMap::new();
-
-    for raw_author in author_lines {
-        let trimmed = raw_author.trim();
-        let author = if trimmed.is_empty() {
-            String::from("Unknown")
-        } else {
-            trimmed.to_string()
-        };
-
-        *author_counts.entry(author).or_insert(0) += 1;
-    }
-
-    let total_commits: usize = author_counts.values().sum();
-
-    let mut author_counts: Vec<(String, usize)> = author_counts.into_iter().collect();
-    author_counts.sort_by(|(author_a, count_a), (author_b, count_b)| {
-        count_b.cmp(count_a).then_with(|| author_a.cmp(author_b))
-    });
-
-    let first_commit_hashes = git::git_command_lines(
-        "find initial commits",
-        vec!["rev-list", "--max-parents=0", "HEAD"],
-    )?;
-
-    let first_commit_hash = first_commit_hashes
-        .first()
-        .ok_or_else(|| String::from("Failed to determine the first commit."))?
-        .trim()
-        .to_string();
-
-    let first_commit_timestamp = git::git_command_lines(
-        "get first commit timestamp",
-        vec!["show", "-s", "--format=%ct", first_commit_hash.as_str()],
-    )?
-    .first()
-    .ok_or_else(|| String::from("Failed to read first commit timestamp."))?
-    .trim()
-    .parse::<u64>()
-    .map_err(|err| format!("Failed to parse first commit timestamp: {err}"))?;
-
-    let first_commit_date = git::git_command_lines(
-        "get first commit date",
-        vec!["show", "-s", "--format=%cs", first_commit_hash.as_str()],
-    )?
-    .first()
-    .map(|date| date.trim().to_string())
-    .unwrap_or_else(|| String::from("unknown"));
-
-    let first_commit_time = UNIX_EPOCH + Duration::from_secs(first_commit_timestamp);
-
-    let since_first_commit = SystemTime::now()
-        .duration_since(first_commit_time)
-        .unwrap_or_else(|_| Duration::from_secs(0));
-
-    println!("Total commits: {total_commits}");
-    println!(
-        "Time since first commit: {} (since {})",
-        format_duration(since_first_commit),
-        first_commit_date
-    );
-    println!("Commits by author:");
-    for (author, count) in author_counts {
-        println!("{author}: {count}");
-    }
-
-    Ok(())
-}
-
 struct TimeRange {
     start_ts: Option<i64>,
     end_ts: i64,
@@ -264,7 +179,7 @@ struct TimeRange {
     end_is_latest: bool,
 }
 
-fn author_stats(options: &AuthorStatsOptions) -> Result<(), String> {
+fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
     let range = resolve_time_range(options)?;
     if let Some(top) = options.top {
         if top == 0 {
@@ -469,7 +384,7 @@ fn print_author_graph(author_counts: &[(String, usize)]) {
     }
 }
 
-fn resolve_time_range(options: &AuthorStatsOptions) -> Result<TimeRange, String> {
+fn resolve_time_range(options: &RepoStatsOptions) -> Result<TimeRange, String> {
     let now = Utc::now();
     let (reference_end_dt, end_label, end_is_latest, end_ts) = if let Some(to_date) = options.to {
         let end_naive = to_date
@@ -555,43 +470,6 @@ fn resolve_time_range(options: &AuthorStatsOptions) -> Result<TimeRange, String>
 fn parse_naive_date(value: &str) -> Result<NaiveDate, String> {
     NaiveDate::parse_from_str(value, "%Y-%m-%d")
         .map_err(|err| format!("Invalid date `{value}` (expected YYYY-MM-DD): {err}"))
-}
-
-fn format_duration(duration: Duration) -> String {
-    let mut seconds = duration.as_secs();
-
-    if seconds == 0 {
-        return String::from("0s");
-    }
-
-    let years = seconds / 31_536_000;
-    seconds %= 31_536_000;
-
-    let days = seconds / 86_400;
-    seconds %= 86_400;
-    let hours = seconds / 3_600;
-    seconds %= 3_600;
-    let minutes = seconds / 60;
-
-    let mut parts = Vec::new();
-    if years > 0 {
-        parts.push(format!("{years}y"));
-    }
-    if days > 0 {
-        parts.push(format!("{days}d"));
-    }
-    if hours > 0 {
-        parts.push(format!("{hours}h"));
-    }
-    if minutes > 0 {
-        parts.push(format!("{minutes}m"));
-    }
-    let remaining_seconds = duration.as_secs() % 60;
-    if parts.is_empty() || remaining_seconds > 0 && parts.len() < 3 {
-        parts.push(format!("{remaining_seconds}s"));
-    }
-
-    parts.join(" ")
 }
 
 fn rebase(target: &str) -> Result<(), String> {


### PR DESCRIPTION
Consolidate `stats` functionality by moving the top-level `stats` command's richer author analysis to `lk repo stats` and removing the old `lk stats`.

The goal was to unify the two existing `stats` commands, making the more comprehensive author analysis available under the `repo` subcommand and eliminating the simpler, top-level `stats` command to avoid redundancy and improve CLI consistency. This is a breaking change, hence the version bump.

---
<a href="https://cursor.com/background-agent?bcId=bc-01c25e17-b956-47f1-9c9f-1084e7af5823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01c25e17-b956-47f1-9c9f-1084e7af5823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

