### PR TITLE
Automate crate deployment on main branch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Deploy Crate
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Add `push` trigger to the deploy crate workflow to automate deployments on changes to `main`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc5af45e-e0df-46e9-89dc-92b2f1b4ef39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc5af45e-e0df-46e9-89dc-92b2f1b4ef39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

