### PR TITLE
Rep stats performance and progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "1.5.1"
+version = "1.5.2"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,16 @@
 pub mod git;
 pub mod pruning;
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::HashMap,
+    io::{BufRead, Write},
+    process::{Command, Stdio},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use chrono::{DateTime, Duration as ChronoDuration, Months, NaiveDate, Utc};
 use clap::{
@@ -193,69 +202,92 @@ struct TimeRange {
 }
 
 fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
+    let progress = start_delayed_progress_meter("Computing repo stats...", Duration::from_secs(1));
+
     let range = resolve_time_range(options)?;
     if let Some(top) = options.top {
         if top == 0 {
             return Err(String::from("--top must be greater than zero."));
         }
     }
-    let log_lines = git::git_command_lines(
-        "collect author stats",
-        vec![
-            "log",
-            "--first-parent",
-            "--pretty=format:%ct%x09%an%x09%ae",
-            "HEAD",
-        ],
-    )?;
 
     let mut totals: HashMap<String, usize> = HashMap::new();
     let mut email_to_name: HashMap<String, String> = HashMap::new();
     let mut email_aliases: HashMap<String, String> = HashMap::new();
     let mut name_to_email: HashMap<String, String> = HashMap::new();
-    let mut timeline: BTreeMap<NaiveDate, HashMap<String, usize>> = BTreeMap::new();
+    let mut latest_commit_date_in_range: Option<NaiveDate> = None;
 
-    for raw_line in log_lines {
+    let name_filters_lower: Vec<String> = options.names.iter().map(|s| s.to_lowercase()).collect();
+    let email_filters_lower: Vec<String> =
+        options.emails.iter().map(|s| s.to_lowercase()).collect();
+
+    let mut git_args: Vec<String> = vec![
+        "log".to_string(),
+        "--first-parent".to_string(),
+        "--pretty=format:%ct%x09%an%x09%ae".to_string(),
+    ];
+    if let Some(start_ts) = range.start_ts {
+        git_args.push(format!("--since=@{start_ts}"));
+    }
+    if !range.end_is_latest {
+        git_args.push(format!("--until=@{}", range.end_ts));
+    }
+    git_args.push("HEAD".to_string());
+
+    let mut child = Command::new("git")
+        .args(git_args)
+        .stdout(Stdio::piped())
+        // Avoid buffering/stalling on stderr while still surfacing errors.
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|err| format!("collect author stats failed to start: {err}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| String::from("collect author stats failed to capture stdout"))?;
+    let reader = std::io::BufReader::new(stdout);
+
+    for raw_line in reader.lines() {
+        let raw_line = raw_line
+            .map_err(|err| format!("Failed to read git log output: {err}"))?;
         let trimmed = raw_line.trim();
         if trimmed.is_empty() {
             continue;
         }
 
-        let parts: Vec<&str> = trimmed.split('\t').collect();
-        if parts.len() != 3 {
+        let mut parts = trimmed.splitn(3, '\t');
+        let (timestamp_part, name_part, email_part) =
+            match (parts.next(), parts.next(), parts.next()) {
+                (Some(ts), Some(name), Some(email)) => (ts, name, email),
+                _ => {
+                    return Err(format!(
+                        "Unexpected git log output (expected `<timestamp>\\t<name>\\t<email>`): `{trimmed}`"
+                    ));
+                }
+            };
+        if timestamp_part.is_empty() {
             return Err(format!(
                 "Unexpected git log output (expected `<timestamp>\\t<name>\\t<email>`): `{trimmed}`"
             ));
         }
-        let timestamp_part = parts[0];
-        let name_part = parts[1];
-        let email_part = parts[2];
 
         let timestamp = timestamp_part.parse::<i64>().map_err(|err| {
             format!("Failed to parse git log timestamp `{timestamp_part}`: {err}")
         })?;
 
-        if timestamp > range.end_ts {
-            continue;
-        }
-        if let Some(start_ts) = range.start_ts {
-            if timestamp < start_ts {
-                continue;
-            }
-        }
-
         let email = email_part.trim();
-        let email = if email.is_empty() {
-            String::from("Unknown")
-        } else {
-            email.to_string()
-        };
+        let email = if email.is_empty() { "Unknown" } else { email };
 
         let name = name_part.trim();
         let canonical_email =
-            canonicalize_author(email.as_str(), name, &mut email_aliases, &mut name_to_email);
+            canonicalize_author(email, name, &mut email_aliases, &mut name_to_email);
 
-        if !matches_author_filters(name, canonical_email.as_str(), options) {
+        if !matches_author_filters_lowered(
+            name,
+            canonical_email.as_str(),
+            &name_filters_lower,
+            &email_filters_lower,
+        ) {
             continue;
         }
 
@@ -268,15 +300,25 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
         let date = DateTime::from_timestamp(timestamp, 0)
             .ok_or_else(|| format!("Commit timestamp out of range: {timestamp}"))?
             .date_naive();
+        if latest_commit_date_in_range.is_none() {
+            // `git log` is reverse-chronological, so the first matching commit is the latest.
+            latest_commit_date_in_range = Some(date);
+        }
 
         *totals.entry(canonical_email.clone()).or_insert(0) += 1;
-        timeline
-            .entry(date)
-            .or_default()
-            .entry(canonical_email)
-            .and_modify(|count| *count += 1)
-            .or_insert(1);
     }
+
+    let status = child
+        .wait()
+        .map_err(|err| format!("collect author stats failed to wait: {err}"))?;
+    if !status.success() {
+        return Err(format!(
+            "collect author stats failed with exit code: {}",
+            status.code().unwrap_or(-1)
+        ));
+    }
+
+    progress.finish();
 
     if totals.is_empty() {
         println!(
@@ -300,9 +342,7 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
     };
 
     let resolved_end_label = if range.end_is_latest {
-        timeline
-            .keys()
-            .next_back()
+        latest_commit_date_in_range
             .map(|date| format!("{date} (latest commit)"))
             .unwrap_or_else(|| String::from("latest commit"))
     } else {
@@ -355,6 +395,41 @@ fn canonicalize_author(
         .entry(canonical.clone())
         .or_insert_with(|| canonical.clone());
     canonical
+}
+
+fn matches_author_filters_lowered(
+    name: &str,
+    email: &str,
+    name_filters_lower: &[String],
+    email_filters_lower: &[String],
+) -> bool {
+    if !name_filters_lower.is_empty() {
+        if name.is_empty() {
+            return false;
+        }
+        let name_lower = name.to_lowercase();
+        if !name_filters_lower
+            .iter()
+            .any(|filter| name_lower.contains(filter))
+        {
+            return false;
+        }
+    }
+
+    if !email_filters_lower.is_empty() {
+        if email.is_empty() {
+            return false;
+        }
+        let email_lower = email.to_lowercase();
+        if !email_filters_lower
+            .iter()
+            .any(|filter| email_lower.contains(filter))
+        {
+            return false;
+        }
+    }
+
+    true
 }
 
 fn print_author_graph(author_counts: &[(String, usize)]) {
@@ -495,6 +570,62 @@ fn matches_author_filters(name: &str, email: &str, options: &RepoStatsOptions) -
 fn parse_naive_date(value: &str) -> Result<NaiveDate, String> {
     NaiveDate::parse_from_str(value, "%Y-%m-%d")
         .map_err(|err| format!("Invalid date `{value}` (expected YYYY-MM-DD): {err}"))
+}
+
+struct ProgressMeter {
+    done: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ProgressMeter {
+    fn finish(mut self) {
+        self.done.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+        // Clear the line in case we printed progress.
+        let mut stderr = std::io::stderr();
+        let _ = write!(stderr, "\r{}\r", " ".repeat(80));
+        let _ = stderr.flush();
+    }
+}
+
+impl Drop for ProgressMeter {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+        let mut stderr = std::io::stderr();
+        let _ = write!(stderr, "\r{}\r", " ".repeat(80));
+        let _ = stderr.flush();
+    }
+}
+
+fn start_delayed_progress_meter(message: &'static str, delay: Duration) -> ProgressMeter {
+    let done = Arc::new(AtomicBool::new(false));
+    let done_clone = Arc::clone(&done);
+    let handle = std::thread::spawn(move || {
+        std::thread::sleep(delay);
+        if done_clone.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let spinner = ['|', '/', '-', '\\'];
+        let mut i = 0usize;
+        while !done_clone.load(Ordering::Relaxed) {
+            let mut stderr = std::io::stderr();
+            let _ = write!(stderr, "\r{message} {}", spinner[i % spinner.len()]);
+            let _ = stderr.flush();
+            i = i.wrapping_add(1);
+            std::thread::sleep(Duration::from_millis(120));
+        }
+    });
+
+    ProgressMeter {
+        done,
+        handle: Some(handle),
+    }
 }
 
 fn rebase(target: &str, interactive: bool) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,6 +468,7 @@ fn print_author_graph(author_counts: &[(String, usize)], weeks: f64) {
         let count_str = count.to_string().green();
         let commits_per_week = (*count as f64) / weeks;
         let commits_per_week_str = format!("{commits_per_week:.1}");
+        let commits_per_week_suffix = format!("({commits_per_week_str}/wk)").purple();
 
         // Colorize email addresses (extract email from "Name <email>" format or use as-is)
         let colored_author = if let Some(start) = author_display.find('<') {
@@ -483,7 +484,7 @@ fn print_author_graph(author_counts: &[(String, usize)], weeks: f64) {
             author_display.yellow().to_string()
         };
 
-        println!("({count_str}) {colored_author} ({commits_per_week_str}/wk)");
+        println!("({count_str}) {colored_author} {commits_per_week_suffix}");
     }
 }
 


### PR DESCRIPTION
Optimize `repo stats` performance for large repositories and add a delayed progress meter.

The `repo stats` command previously loaded the entire `git log` into memory and processed it in-app, leading to slow performance on large codebases. This PR streams `git log` output, pushes date filtering directly to `git` using `--since`/`--until` flags, and removes an unused internal timeline data structure. A 1-second delayed, self-clearing progress spinner is also added to improve UX for long-running computations.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc56b987-704a-4f0a-9505-80a068a11bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc56b987-704a-4f0a-9505-80a068a11bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

