### PR TITLE
Repo stats full history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "1.8.0"
+version = "1.9.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ lk x -- commit -m "Update Readme without running hooks"
 ```
 
 ### `repo stats`
-Analyze first-parent commits to see who has been landing work in a repository. All of the filtering flags operate on commit dates.
+Analyze commits reachable from HEAD to see who has been landing work in a repository. All of the filtering flags operate on commit dates.
 
 - `--name` filters by author display name (repeatable, case-insensitive).
 - `--email` filters by author email (repeatable, case-insensitive).

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Analyze commits reachable from HEAD to see who has been landing work in a reposi
 
 - `--name` filters by author display name (repeatable, case-insensitive).
 - `--email` filters by author email (repeatable, case-insensitive).
+- `--first-parent` limits the analysis to first-parent commits.
 
 #### Example
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,10 @@ struct RepoStatsOptions {
     #[clap(long, default_value_t = 20)]
     top: usize,
 
+    /// Only include first-parent commits.
+    #[clap(long, default_value = "false")]
+    first_parent: bool,
+
     /// Only include commits authored by these names (repeatable, case-insensitive fuzzy match).
     #[clap(long = "name", value_name = "NAME")]
     names: Vec<String>,
@@ -231,10 +235,11 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
     let email_filters_lower: Vec<String> =
         options.emails.iter().map(|s| s.to_lowercase()).collect();
 
-    let mut git_args: Vec<String> = vec![
-        "log".to_string(),
-        "--pretty=format:%ct%x09%an%x09%ae".to_string(),
-    ];
+    let mut git_args: Vec<String> = vec!["log".to_string()];
+    if options.first_parent {
+        git_args.push("--first-parent".to_string());
+    }
+    git_args.push("--pretty=format:%ct%x09%an%x09%ae".to_string());
     if let Some(start_ts) = range.start_ts {
         git_args.push(format!("--since=@{start_ts}"));
     }
@@ -338,10 +343,17 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
     progress.finish();
 
     if totals.is_empty() {
-        println!(
-            "No commits found between {} and {}.",
-            range.start_label, range.end_label
-        );
+        if options.first_parent {
+            println!(
+                "No first-parent commits found between {} and {}.",
+                range.start_label, range.end_label
+            );
+        } else {
+            println!(
+                "No commits found between {} and {}.",
+                range.start_label, range.end_label
+            );
+        }
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ struct RepoStatsOptions {
 
 #[derive(Debug, Subcommand)]
 enum RepoSubcommand {
-    /// Analyze first-parent commits by author over time.
+    /// Analyze commits by author over time.
     #[clap(name = "stats")]
     Stats(RepoStatsOptions),
 }
@@ -233,7 +233,6 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
 
     let mut git_args: Vec<String> = vec![
         "log".to_string(),
-        "--first-parent".to_string(),
         "--pretty=format:%ct%x09%an%x09%ae".to_string(),
     ];
     if let Some(start_ts) = range.start_ts {
@@ -340,7 +339,7 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
 
     if totals.is_empty() {
         println!(
-            "No first-parent commits found between {} and {}.",
+            "No commits found between {} and {}.",
             range.start_label, range.end_label
         );
         return Ok(());


### PR DESCRIPTION
Remove `--first-parent` from `repo stats` to include all history reachable from HEAD.

The previous implementation only considered the first parent history, which could omit relevant contributions from merged branches. This change ensures that `repo stats` provides a comprehensive view of all work landed in the repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9fe982c-e8e1-4bf5-9608-bb4f06a19348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9fe982c-e8e1-4bf5-9608-bb4f06a19348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a reporting-only command; primary risk is altered stats output/perf on very large repos when not using `--first-parent`.
> 
> **Overview**
> `repo stats` now analyzes all commits reachable from `HEAD` by default (instead of always using `--first-parent`), with a new `--first-parent` flag to opt back into the previous behavior.
> 
> Docs/help text were updated accordingly, and the empty-result message now distinguishes between “no commits” vs “no first-parent commits”. The crate version was bumped to `1.9.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc11c2647422ecb5a23f31a99fd95124c680f0a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->