### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "1.7.0"
+version = "1.9.0"
 dependencies = [
  "chrono",
  "clap",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump; risk is limited to potential build/runtime behavior changes from the newer `loki-cli` version.
> 
> **Overview**
> Updates the Rust dependency lockfile by bumping `loki-cli` from `1.7.0` to `1.9.0` in `Cargo.lock`. No source code changes are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 100b5df69a228291ba6cde33438d10f47b8e1ac3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->