### PR TITLE
Repo stats log options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 Whenever an automated agent lands code in this repository, it must also:
 
 - Bump the crate version in `Cargo.toml` before shipping.
+- Run `cargo build` so `Cargo.lock` is updated, and commit any lockfile changes.
 - Choose the bump size using semantic versioning rules:
   - Increment the **major** version (`x.0.0`) for breaking changes.
   - Increment the **minor** version when adding backward-compatible functionality.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "1.9.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "1.9.0"
+version = "2.0.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Analyze commits reachable from HEAD to see who has been landing work in a reposi
 
 - `--name` filters by author display name (repeatable, case-insensitive).
 - `--email` filters by author email (repeatable, case-insensitive).
-- `--first-parent` limits the analysis to first-parent commits.
+- `--all` includes all commits (default is first-parent only).
 
 #### Example
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,9 +73,9 @@ struct RepoStatsOptions {
     #[clap(long, default_value_t = 20)]
     top: usize,
 
-    /// Only include first-parent commits.
+    /// Include all commits (disables first-parent-only filtering).
     #[clap(long, default_value = "false")]
-    first_parent: bool,
+    all: bool,
 
     /// Only include commits authored by these names (repeatable, case-insensitive fuzzy match).
     #[clap(long = "name", value_name = "NAME")]
@@ -236,7 +236,7 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
         options.emails.iter().map(|s| s.to_lowercase()).collect();
 
     let mut git_args: Vec<String> = vec!["log".to_string()];
-    if options.first_parent {
+    if !options.all {
         git_args.push("--first-parent".to_string());
     }
     git_args.push("--pretty=format:%ct%x09%an%x09%ae".to_string());
@@ -343,14 +343,14 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
     progress.finish();
 
     if totals.is_empty() {
-        if options.first_parent {
+        if options.all {
             println!(
-                "No first-parent commits found between {} and {}.",
+                "No commits found between {} and {}.",
                 range.start_label, range.end_label
             );
         } else {
             println!(
-                "No commits found between {} and {}.",
+                "No first-parent commits found between {} and {}.",
                 range.start_label, range.end_label
             );
         }


### PR DESCRIPTION
Invert the default behavior of `repo stats` to analyze first-parent commits by default, adding an `--all` flag to include the full commit history.

---
<a href="https://cursor.com/background-agent?bcId=bc-556fe289-7e14-4876-b894-278f06e2d276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-556fe289-7e14-4876-b894-278f06e2d276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI flag/argument behavior change plus a version bump; no security-sensitive logic or data migrations involved.
> 
> **Overview**
> `repo stats` now defaults to analyzing only first-parent commits, and adds an `--all` flag to include the full history (implemented by toggling `git log --first-parent`).
> 
> Updates help text/README messaging to match the new behavior, and bumps the crate version to `2.0.0` with corresponding `Cargo.lock` updates plus an agent guideline to run `cargo build` to refresh the lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e10dbdec2803f55ecb88407b9a97141ef208ff45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->