### PR TITLE
Harden worktree remove with pre-validation and rename --base to --branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "2.4.0"
+version = "2.5.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn styles() -> clap::builder::Styles {
         .placeholder(AnsiColor::Cyan.on_default())
 }
 
-use vars::{LOKI_NEW_PREFIX, LOKI_REBASE_TARGET, LOKI_WORKTREE_BASE, NO_HOOKS};
+use vars::{LOKI_NEW_PREFIX, LOKI_REBASE_TARGET, LOKI_WORKTREE_BRANCH, NO_HOOKS};
 
 #[derive(Debug, Parser)]
 struct CommitOptions {
@@ -105,9 +105,10 @@ enum WorktreeSubcommand {
         #[clap(long, env = LOKI_NEW_PREFIX)]
         prefix: Option<String>,
 
-        /// Base ref to create the worktree from.
-        #[clap(short, long, default_value = "origin/main", env = LOKI_WORKTREE_BASE)]
-        base: String,
+        /// Branch to check out if it exists on the remote, or the starting
+        /// point for a new branch.
+        #[clap(short, long, default_value = "origin/main", env = LOKI_WORKTREE_BRANCH)]
+        branch: String,
 
         /// Name parts joined with dashes to form the worktree and branch name.
         name: Vec<String>,
@@ -232,8 +233,8 @@ fn main() -> Result<(), String> {
             command: RepoSubcommand::Stats(options),
         } => repo_stats(options),
         Cli::Worktree { command } => match command {
-            WorktreeSubcommand::Add { name, base, prefix } => {
-                worktree::worktree_add(name, base, prefix.as_deref())
+            WorktreeSubcommand::Add { name, branch, prefix } => {
+                worktree::worktree_add(name, branch, prefix.as_deref())
             }
             WorktreeSubcommand::Remove { name, force } => {
                 worktree::worktree_remove(name, *force)

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -1,8 +1,8 @@
 /// Environment variable for the branch name prefix used by `new` and `worktree add`.
 pub const LOKI_NEW_PREFIX: &str = "LOKI_NEW_PREFIX";
 
-/// Environment variable for the base ref used by `worktree add`.
-pub const LOKI_WORKTREE_BASE: &str = "LOKI_WORKTREE_BASE";
+/// Environment variable for the branch used by `worktree add`.
+pub const LOKI_WORKTREE_BRANCH: &str = "LOKI_WORKTREE_BRANCH";
 
 /// Environment variable for the rebase target branch.
 pub const LOKI_REBASE_TARGET: &str = "LOKI_REBASE_TARGET";

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -234,9 +234,9 @@ fn list_worktree_entries() -> Result<Vec<WorktreeEntry>, String> {
 // ---------------------------------------------------------------------------
 
 /// Creates a worktree at `<parent>/<repo>_<name>`, then creates and pushes a
-/// branch with optional prefix. If the base ref is an existing remote branch,
+/// branch with optional prefix. If the branch is an existing remote branch,
 /// checks it out directly instead. Outputs `cd <path>` to stdout for piping.
-pub fn worktree_add(name: &[String], base: &str, prefix: Option<&str>) -> Result<(), String> {
+pub fn worktree_add(name: &[String], branch: &str, prefix: Option<&str>) -> Result<(), String> {
     if name.is_empty() {
         return Err(String::from("name cannot be empty."));
     }
@@ -250,11 +250,11 @@ pub fn worktree_add(name: &[String], base: &str, prefix: Option<&str>) -> Result
         return Err(format!("Worktree path already exists: {wt_path_str}"));
     }
 
-    // Check if the base is an existing remote branch to check out directly
-    if let Some(remote_ref) = find_remote_branch(base) {
+    // Check if the branch is an existing remote branch to check out directly
+    if let Some(remote_ref) = find_remote_branch(branch) {
         eprintln!(
             "Found existing branch {} — checking out into worktree",
-            base.cyan()
+            branch.cyan()
         );
         git_command_status_quiet("fetch", vec!["fetch", "origin"])?;
         git_command_status_quiet(
@@ -264,7 +264,7 @@ pub fn worktree_add(name: &[String], base: &str, prefix: Option<&str>) -> Result
                 "add",
                 "--track",
                 "-b",
-                base,
+                branch,
                 wt_path_str.as_ref(),
                 remote_ref.as_str(),
             ],
@@ -282,7 +282,7 @@ pub fn worktree_add(name: &[String], base: &str, prefix: Option<&str>) -> Result
     eprintln!("Creating worktree at {}", wt_path_str.green());
     git_command_status_quiet(
         "worktree add",
-        vec!["worktree", "add", wt_path_str.as_ref(), base],
+        vec!["worktree", "add", wt_path_str.as_ref(), branch],
     )?;
 
     std::env::set_current_dir(&wt_path)

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -76,6 +76,80 @@ fn emit_cd(path: &str) {
     }
 }
 
+/// Verifies that the given path is a registered git worktree.
+fn verify_worktree_registered(path: &Path) -> Result<(), String> {
+    let normalized = normalize_path(&path.to_string_lossy());
+
+    for line in git_command_iter("list worktrees", vec!["worktree", "list", "--porcelain"])? {
+        if let Some(wt_path) = line.strip_prefix("worktree ") {
+            if normalize_path(wt_path) == normalized {
+                return Ok(());
+            }
+        }
+    }
+
+    Err(format!(
+        "Path '{}' is not a registered git worktree.\n\
+         Run `git worktree list` to see registered worktrees.",
+        path.display()
+    ))
+}
+
+/// Probes whether a directory can be removed by attempting a rename.
+/// On Windows, directories held open by a shell or other process cannot be
+/// renamed, so this detects locks *before* `git worktree remove` modifies any
+/// internal state.
+fn probe_directory_removable(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Cannot determine parent of '{}'", path.display()))?;
+    let dir_name = path
+        .file_name()
+        .ok_or_else(|| format!("Cannot determine directory name of '{}'", path.display()))?;
+
+    let probe_name = format!(".{}.lk-removing", dir_name.to_string_lossy());
+    let probe_path = parent.join(&probe_name);
+
+    if probe_path.exists() {
+        return Err(format!(
+            "Found stale probe directory '{}' from a previous interrupted removal.\n\
+             Please manually rename it back to '{}' or delete it.",
+            probe_path.display(),
+            path.display()
+        ));
+    }
+
+    match std::fs::rename(path, &probe_path) {
+        Ok(()) => {
+            // Rename succeeded — directory is not locked. Rename it back.
+            std::fs::rename(&probe_path, path).map_err(|e| {
+                format!(
+                    "Renamed worktree directory for probe but failed to restore it.\n\
+                     Please manually rename '{}' back to '{}': {e}",
+                    probe_path.display(),
+                    path.display()
+                )
+            })
+        }
+        Err(e) => {
+            let hint = if cfg!(windows) {
+                " On Windows this usually means a shell or program has its working \
+                 directory inside the worktree. Close that terminal or `cd` elsewhere first."
+            } else {
+                ""
+            };
+            Err(format!(
+                "Cannot remove worktree: directory '{}' is locked: {e}.{hint}",
+                path.display()
+            ))
+        }
+    }
+}
+
 /// Checks if a ref matches an existing remote branch on origin.
 /// Returns the full remote ref (e.g. `origin/branch-name`) if found.
 fn find_remote_branch(name: &str) -> Option<String> {
@@ -272,12 +346,17 @@ pub fn worktree_remove(name: &[String], force: bool) -> Result<(), String> {
     };
     let wt_path_str = wt_path.to_string_lossy();
 
-    // Don't allow removing the main worktree
+    // -- Pre-validation: catch problems before git modifies any state --------
+
+    // 1. Refuse to remove the main worktree.
     if normalize_path(&wt_path_str) == normalize_path(&main_root) {
         return Err(String::from(
             "You're in the main repo - only secondary worktrees can be removed.",
         ));
     }
+
+    // 2. Verify the worktree is actually registered with git.
+    verify_worktree_registered(&wt_path)?;
 
     // Look up the actual branch checked out in this worktree before removing
     let actual_branch = list_worktree_entries()
@@ -290,7 +369,8 @@ pub fn worktree_remove(name: &[String], force: bool) -> Result<(), String> {
                 .and_then(|e| e.branch)
         });
 
-    // Move out of the worktree so the OS can delete it
+    // 3. If we are inside the worktree, move out first so our own process
+    //    does not hold a directory lock.
     if let Ok(cwd) = std::env::current_dir() {
         if cwd.starts_with(&wt_path) {
             eprintln!(
@@ -301,6 +381,12 @@ pub fn worktree_remove(name: &[String], force: bool) -> Result<(), String> {
                 .map_err(|e| format!("Failed to change to main worktree: {e}"))?;
         }
     }
+
+    // 4. Probe that the directory can actually be removed (rename test).
+    //    On Windows this catches locks held by other shells/processes.
+    probe_directory_removable(&wt_path)?;
+
+    // -- All checks passed — safe to proceed ---------------------------------
 
     // Attempt worktree removal — retry with --force on dirty worktree errors
     let mut remove_args = vec!["worktree", "remove"];


### PR DESCRIPTION
## Worktree remove pre-validation

When `lk w r` fails to delete the worktree directory (e.g. `Permission Denied` on Windows because a shell holds a directory lock), `git worktree remove` may have already unregistered the worktree internally. This leaves a corrupted state where the directory still exists but git no longer tracks it, causing subsequent commands to fail with *Could not determine main worktree from git worktree list*.

This PR adds four pre-validation steps that run **before** `git worktree remove` modifies any state:

1. **Refuse main worktree** - prevents accidentally removing the primary repo when running `lk w r` from the main worktree with no arguments.
2. **verify_worktree_registered()** - confirms the path appears in `git worktree list` so we get a clear error for stale/orphaned directories.
3. **Move CWD out of worktree** - if our process is inside the worktree, `set_current_dir` to the main worktree so we don't hold a directory lock (previously just a warning).
4. **probe_directory_removable()** - attempts a rename of the directory to detect OS-level locks. On Windows, a directory cannot be renamed while any process has its CWD inside it, so this catches the exact failure mode that previously corrupted state.

## Rename --base to --branch

The `--base` flag on `worktree add` was ambiguous - it serves as either a branch to check out from the remote or the starting point for a new branch. Since worktree add always deals with branches (not arbitrary commits or refs), `--branch` better describes the intent.

- `--base` -> `--branch` (short flag `-b` unchanged)
- `LOKI_WORKTREE_BASE` -> `LOKI_WORKTREE_BRANCH` env var
- Updated help text: *Branch to check out if it exists on the remote, or the starting point for a new branch.*