### PR TITLE
feat(repo stats): default to walking all commits (with patch-id dedup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loki-cli"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-cli"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Kyle W. Rader"]
 description = "Loki: 🚀 A Git productivity tool"
 homepage = "https://github.com/kyle-rader/loki-cli"

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Analyze commits reachable from HEAD to see who has been landing work in a reposi
 
 - `--name` filters by author display name (repeatable, case-insensitive).
 - `--email` filters by author email (repeatable, case-insensitive).
-- `--all` includes all commits (default is first-parent only).
+- `--first-parent` restricts the walk to the first-parent chain of HEAD (one tally per merge commit). Default walks all commits reachable from HEAD, relying on patch-id dedup to handle rebased / cherry-picked / migrated history.
 - `--no-dedup` disables patch-id deduplication (see below).
 
 #### Patch-id deduplication

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,8 +75,19 @@ struct RepoStatsOptions {
     #[clap(long, default_value_t = 20)]
     top: usize,
 
-    /// Include all commits (disables first-parent-only filtering).
-    #[clap(long, default_value = "false")]
+    /// Only count commits on the first-parent chain of HEAD.
+    ///
+    /// By default `lk repo stats` walks every commit reachable from HEAD
+    /// (with patch-id deduplication applied so logically-identical commits
+    /// from rebases / cherry-picks / cross-repo migrations are counted
+    /// once). Pass `--first-parent` to restrict the walk to the mainline
+    /// of merges into HEAD — useful when each PR is merged with a merge
+    /// commit and you want one tally per PR.
+    #[clap(long, default_value_t = false)]
+    first_parent: bool,
+
+    /// Deprecated: walking all commits is now the default; this flag is a no-op.
+    #[clap(long, default_value_t = false, hide = true)]
     all: bool,
 
     /// Only include commits authored by these names (repeatable, case-insensitive fuzzy match).
@@ -384,14 +395,14 @@ fn repo_stats(options: &RepoStatsOptions) -> Result<(), String> {
     progress.finish();
 
     if totals.is_empty() {
-        if options.all {
+        if options.first_parent {
             println!(
-                "No commits found between {} and {}.",
+                "No first-parent commits found between {} and {}.",
                 range.start_label, range.end_label
             );
         } else {
             println!(
-                "No first-parent commits found between {} and {}.",
+                "No commits found between {} and {}.",
                 range.start_label, range.end_label
             );
         }
@@ -464,7 +475,7 @@ fn collect_raw_commits(
     range: &TimeRange,
 ) -> Result<Vec<RawCommit>, String> {
     let mut git_args: Vec<String> = vec!["log".to_string()];
-    if !options.all {
+    if options.first_parent {
         git_args.push("--first-parent".to_string());
     }
     git_args.push("--pretty=format:%H%x09%ct%x09%an%x09%ae".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,10 +86,6 @@ struct RepoStatsOptions {
     #[clap(long, default_value_t = false)]
     first_parent: bool,
 
-    /// Deprecated: walking all commits is now the default; this flag is a no-op.
-    #[clap(long, default_value_t = false, hide = true)]
-    all: bool,
-
     /// Only include commits authored by these names (repeatable, case-insensitive fuzzy match).
     #[clap(long = "name", value_name = "NAME")]
     names: Vec<String>,


### PR DESCRIPTION
## Problem

In v2.0.0 (Feb 2, 2026) we flipped the default commit walk in `lk repo stats` to `--first-parent` as a workaround for inflated contributor counts after merging a large external history into a downstream repo. That workaround over-corrected: it silently drops **all authorship from history that was merged in via a side-parent** — i.e. it hides every commit behind a graft merge from the contributor view.

Now that patch-id dedup (v2.5.0, PR #40) handles the duplicate-commit inflation properly, the `--first-parent` default is no longer needed and is actively wrong: it suppresses real contributions.

### Case study (same repo as v2.5.0)

| Mode | Total commits | Top entry for the migration driver |
| --- | ---: | --- |
| v2.0.x-v2.5.x default (`--first-parent`) | 3,288 | 131 commits over 6.1 months  ❌ drops 14+ months of work |
| **v2.6.0 default (all + dedup)** | 4,476 (838 collapsed) | **413 commits over 1.2 years**  ✅ matches reality |
| `--no-dedup` for reference | 5,314 | 704 commits over 1.2 years  ❌ inflated by ~290 dup patches |

(The same person's oldest commit reachable from HEAD via `--first-parent` is 2025-11-17; via all refs it's 2025-03-10. The first-parent walk hides 8 months of legitimate authorship.)

## Solution

- Drop the old `--all` opt-in flag (it became meaningless once "all" is the default).
- Add a new `--first-parent` opt-in flag for users who want the one-tally-per-merge release-history view.
- Update the help text and README to reflect the new model: default = all commits with patch-id dedup; opt into `--first-parent` when you want PR-granularity.

## Compat

Defaults change. Anyone scripted on the old default gets the (more accurate) all-commits view; they can restore previous output with `--first-parent`. The old default existed for ~3.5 months. Anyone scripted on `lk repo stats --all` should drop the flag — it now errors.

Bumps the crate version **2.5.0 → 2.6.0**.